### PR TITLE
add command glossary to docs

### DIFF
--- a/docs/assets/stylesheets/admonitions.css
+++ b/docs/assets/stylesheets/admonitions.css
@@ -2,6 +2,7 @@
   --md-admonition-icon--command: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d='M0 96C0 60.7 28.7 32 64 32H448c35.3 0 64 28.7 64 64V416c0 35.3-28.7 64-64 64H64c-35.3 0-64-28.7-64-64V96zm102.3 55.8c-9 9.8-8.3 25 1.5 33.9L180.5 256l-76.7 70.3c-9.8 9-10.4 24.1-1.5 33.9s24.1 10.4 33.9 1.5l96-88c5-4.5 7.8-11 7.8-17.7s-2.8-13.1-7.8-17.7l-96-88c-9.8-9-25-8.3-33.9 1.5zM248 336c-13.3 0-24 10.7-24 24s10.7 24 24 24H392c13.3 0 24-10.7 24-24s-10.7-24-24-24H248z'/></svg>");
   --md-admonition-icon--guide: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 512'><!--! Font Awesome Pro 6.3.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d='M304 32V408L96 368V34.7C96 14.9 113.8-.2 133.3 3.1L304 32zM89.7 405.1L320 451.2l230.3-46.1c15-3 25.7-16.1 25.7-31.4V28.8l25.7-5.1C621.5 19.7 640 34.8 640 55V421.8c0 15.3-10.8 28.4-25.7 31.4L320 512 25.7 453.1C10.8 450.2 0 437 0 421.8V55C0 34.8 18.5 19.7 38.3 23.7L64 28.8v345c0 15.3 10.8 28.4 25.7 31.4zM336 408V32L506.7 3.1C526.2-.2 544 14.9 544 34.7V368L336 408z'/></svg>");
   --md-admonition-icon--voice: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d='M192 0C139 0 96 43 96 96V256c0 53 43 96 96 96s96-43 96-96V96c0-53-43-96-96-96zM64 216c0-13.3-10.7-24-24-24s-24 10.7-24 24v40c0 89.1 66.2 162.7 152 174.4V464H120c-13.3 0-24 10.7-24 24s10.7 24 24 24h72 72c13.3 0 24-10.7 24-24s-10.7-24-24-24H216V430.4c85.8-11.7 152-85.3 152-174.4V216c0-13.3-10.7-24-24-24s-24 10.7-24 24v40c0 70.7-57.3 128-128 128s-128-57.3-128-128V216z'/></svg>");
+  --md-admonition-icon--restrict: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512'><!--! Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc. --><path d='M367.2 412.5L99.5 144.8C77.1 176.1 64 214.5 64 256c0 106 86 192 192 192c41.5 0 79.9-13.1 111.2-35.5zm45.3-45.3C434.9 335.9 448 297.5 448 256c0-106-86-192-192-192c-41.5 0-79.9 13.1-111.2 35.5L412.5 367.2zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z'/></svg>");
 }
 
 /* Command Admonition */
@@ -64,4 +65,28 @@
 .md-typeset .voice > .admonition-title:after,
 .md-typeset .voice > summary:after {
   color: #7c4dff;
+}
+
+/* Restrict Admonition */
+
+.md-typeset .admonition.restrict,
+.md-typeset details.restrict {
+  border-color: #ff5252;
+}
+
+.md-typeset .restrict > .admonition-title,
+.md-typeset .restrict > summary {
+  background-color: #ff52521a;
+}
+
+.md-typeset .restrict > .admonition-title:before,
+.md-typeset .restrict > summary:before {
+  background-color: #ff5252;
+  -webkit-mask-image: var(--md-admonition-icon--restrict);
+  mask-image: var(--md-admonition-icon--restrict);
+}
+
+.md-typeset .restrict > .admonition-title:after,
+.md-typeset .restrict > summary:after {
+  color: #ff5252;
 }

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -1,0 +1,177 @@
+---
+icon: command
+hide:
+    - footer
+---
+
+# Command Glossary[^1]
+
+## General
+
+### /about
+
+View information about 3515.games.
+
+### /caniplay
+
+See the games 3515.games can play with the permissions it has in a given channel.
+
+### /help
+
+Get help with 3515.games.
+
+### /pronouns
+
+View information about choosing the pronouns with which 3515.games refers to you.
+
+??? info "See Also"
+
+    - [Pronouns](/games/features/pronouns)
+
+### /voice
+
+Create a linked voice channel for a supported game.
+
+??? info "See Also"
+
+    - [Voice Chat](/games/features/voice)
+
+## Rock-Paper-Scissors
+
+??? info "See Also"
+
+    - [Rock-Paper-Scissors](/games/rps)
+
+### /rps challenge
+
+Challenge someone to a game of Rock-Paper-Scissors.
+
+??? restrict "Restrictions"
+
+    This command can't be used in threads.
+
+
+## UNO
+
+??? info "See Also"
+
+    - [UNO](/games/uno)
+
+### /uno create
+
+Create an UNO game.
+
+??? restrict "Restrictions"
+
+    - This command can't be used in threads.
+    - This command can't be used by someone already hosting an UNO game in the same server.
+
+
+### /uno ciao
+
+Join or leave the game.
+
+### /uno play
+
+Take an action. Use this command to play and draw cards, view your hand, make callouts, and say "UNO!".
+
+??? restrict "Restrictions"
+
+    The following options of this command can only be used on the invoker's turn:
+
+    - Play Card
+    - Draw Cards
+    - Make Callout
+
+### /uno manage
+
+Manage the game. Use this command to start the game and take other administrative actions.
+
+??? restrict "Restrictions"
+
+    This command can only be used by the Game Host of the relevant UNO game.
+
+
+### /uno status
+
+View statistics about the game.
+
+## Chess
+
+??? info "See Also"
+
+    - [Chess](/games/chess)
+
+### /chess challlenge
+
+Challenge someone to a game of chess.
+
+??? restrict "Restrictions"
+
+    - This command can't be used in threads.
+    - This command can't be targeted at a user with whom the invoker is in an ongoing chess game in the same server.
+
+### /chess ready
+
+Indicate that you are ready to begin the game.
+
+### /chess move
+
+Make a move.
+
+### /chess board
+
+View the current state of the board.
+
+### /chess draw
+
+Propose to your opponent to end the game in a draw.
+
+### /chess forfeit
+
+Forfeit the game.
+
+### /chess replay
+
+Revisit saved chess games.
+
+## Cards Against Humanity
+
+??? info "See Also"
+
+    - [Cards Against Humanity](/games/cah)
+
+### /cah create
+
+Create a Cards Against Humanity game.
+
+??? restrict "Restrictions"
+
+    - This command can't be used in threads.
+    - This command can't be used by someone already hosting a Cards Aganist Humanity game in the same server.
+
+### /cah ciao
+
+Join or leave the game.
+
+### /cah play
+
+Play white cards or vote for a submission.
+
+### /cah hand
+
+View the white cards you're currently holding.
+
+### /cah manage
+
+Manage the game. Use this command to start the game and take other administrative actions.
+
+??? restrict "Restrictions"
+
+    This command can only be used by the Game Host of the relevant Cards Against Humanity game.
+
+### /cah status
+
+View statistics about the game.
+
+[^1]: Command descriptions on this page may not be identical to what you see on Discord.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Special Features:
           - Voice Chat: games/features/voice.md
           - Pronouns: games/features/pronouns.md
+  - Commands: commands/index.md
   - Changelog: changelog/index.md
   - Self-Hosting:
       - Self-Hosting: hosting/index.md


### PR DESCRIPTION
- Bump beautifulsoup4 from 4.12.0 to 4.12.1
- exclude legal pages from search
- update `kurisu copyright` to account for black formatting
- fix bug in `kurisu invite` where `--production` flag would generate a link for the development bot
- use `split()` for `subprocess` commands
- add success message to `kurisu licenses`
- add command glossary to docs
